### PR TITLE
Add support for tracing messages

### DIFF
--- a/include/tr.hrl
+++ b/include/tr.hrl
@@ -1,9 +1,12 @@
--record(tr, {index :: pos_integer(),
+-record(msg, {to :: pid(), exists :: boolean()}).
+
+-record(tr, {index :: tr:index(),
              pid :: pid(),
-             event :: call | return_from | exception_from,
-             mfa :: {module(), atom(), non_neg_integer()},
+             event :: call | return | exception | send | recv,
+             mfa :: mfa() | undefined,
              data :: term(),
-             ts :: integer()}).
+             ts :: integer(),
+             extra :: #msg{} | undefined}).
 
 -record(node, {module :: module(),
                function :: atom(),


### PR DESCRIPTION
Originally requested by @michalwski.

After some experiments it turned out that tracing messages from all processes could collect huge amounts of data. Of course you can provide a list of Pids (or collect them from a supervision tree), but it is a bit hard, and new ones may be spawned. The solution is to collect messages for each Pid only after a call from that Pid is traced - this way all messages from that point will be traced, and only the messages before the initial call can be missed. You can change it and trace all messes with `#{msg_trigger => always}`.

Also: improve tests.