### PR TITLE
Use a default timeout of 2 minutes in tr:dump/1

### DIFF
--- a/src/tr.erl
+++ b/src/tr.erl
@@ -183,7 +183,7 @@ load(File) ->
 
 -spec dump(string()) -> ok | {error, any()}.
 dump(File) ->
-    gen_server:call(?MODULE, {dump, File}).
+    gen_server:call(?MODULE, {dump, File}, timer:minutes(2)).
 
 -spec clean() -> ok.
 clean() ->


### PR DESCRIPTION
A big trace table might time out, so the default 5 seconds are not enough. Two minutes seems "infinite enough" for an interactive tool.