### PR TITLE
Add edoc comments to generate detailed hex docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,7 @@ They are stored as `#tr` records with the following fields:
 - `mfa`: `{Module, Function, Arity}` for function traces; `no_mfa` for messages.
 - `data`: argument list (for calls), returned value (for returns) or class and value (for exceptions).
 - `timestamp` in microseconds.
-- `info`: For function traces and `recv` events it is `no_info`. For `send` events it is a `#msg` record with the following fields:
-    - `to`: message recipient (pid),
-    - `exists`: boolean, indicates if the recipient process existed.
+- `info`: For function traces and `recv` events it is `no_info`. For `send` events it is a `{To, Exists}` tuple, where `To` is the recipient pid, and `Exists` is a boolean indicating if the recipient process existed.
 
 It's useful to read the record definitions before trace analysis:
 

--- a/test/tr_SUITE.erl
+++ b/test/tr_SUITE.erl
@@ -99,8 +99,7 @@ single_pid_with_msg(_Config) ->
     [#tr{index = 1, event = recv, pid = Pid, data = {do_factorial, 0, Self}},
      #tr{index = 2, event = call, mfa = MFA, pid = Pid, data = [0]},
      #tr{index = 3, event = return, mfa = MFA, pid = Pid, data = 1},
-     #tr{index = 4, event = send, pid = Pid, data = {ok, 1},
-         info = #msg{to = Self, exists = true}}] = tr:select().
+     #tr{index = 4, event = send, pid = Pid, data = {ok, 1}, info = {Self, true}}] = tr:select().
 
 msg_after_traced_call(_Config) ->
     Pid = spawn_link(fun ?MODULE:async_factorial/0),
@@ -116,8 +115,7 @@ msg_after_traced_call(_Config) ->
     %% message traces for Pid are stored after the call to factorial/1
     [#tr{index = 1, event = call, mfa = MFA, pid = Pid, data = [0]},
      #tr{index = 2, event = return, mfa = MFA, pid = Pid, data = 1},
-     #tr{index = 3, event = send, pid = Pid, data = {ok, 1},
-         info = #msg{to = Self, exists = true}},
+     #tr{index = 3, event = send, pid = Pid, data = {ok, 1}, info = {Self, true}},
      #tr{index = 4, event = recv, pid = Pid, data = stop}] = tr:select().
 
 ranges(_Config) ->
@@ -520,11 +518,9 @@ trace_wait_and_reply() ->
     wait_for_traces(5),
     tr:stop_tracing(),
     [#tr{index = 1, pid = Pid, event = call, mfa = MFA, data = [Self]},
-     #tr{index = 2, pid = Pid, event = send, data = {started, Pid},
-         info = #msg{to = Self, exists = true}},
+     #tr{index = 2, pid = Pid, event = send, data = {started, Pid}, info = {Self, true}},
      #tr{index = 3, pid = Pid, event = recv, data = reply},
-     #tr{index = 4, pid = Pid, event = send, data = {finished, Pid},
-         info = #msg{to = Self, exists = true}},
+     #tr{index = 4, pid = Pid, event = send, data = {finished, Pid}, info = {Self, true}},
      #tr{index = 5, pid = Pid, event = return, mfa = MFA, data = {finished, Pid}}
     ] = tr:select().
 


### PR DESCRIPTION
Also:
- Simplify the `#msg{}` record to a tuple. It is easier to spec and describe in ex_doc.
- Fix issues with conflicts on dumping and loading tables.
- Allow binaries for dump/load to limit Elixir issues.