### PR TITLE
Use a separate tracer process

### DIFF
--- a/src/erlang_doctor.app.src
+++ b/src/erlang_doctor.app.src
@@ -7,7 +7,7 @@
    [kernel,
     stdlib
    ]},
-  {env,[]},
+  {env, [{limit, infinity}]},
   {modules, []},
   {maintainers, []},
   {licenses, ["Apache 2.0"]},

--- a/src/tr.erl
+++ b/src/tr.erl
@@ -508,7 +508,9 @@ ts(#tr{ts = TS}) -> calendar:system_time_to_rfc3339(TS, [{unit, microsecond}]).
 -spec init(init_options()) -> {ok, state()}.
 init(Opts) ->
     process_flag(trap_exit, true),
-    Defaults = #{tab => default_tab(), index => initial_index(), limit => infinity},
+    Defaults = #{tab => default_tab(),
+                 index => initial_index(),
+                 limit => application:get_env(erlang_doctor, limit, infinity)},
     FinalOpts = #{tab := Tab} = maps:merge(Defaults, Opts),
     State = maps:merge(FinalOpts, #{trace => none, tracer_pid => none}),
     create_tab(Tab),


### PR DESCRIPTION
The main motivation is to quickly stop tracing when needed without waiting for the queued trace messages to be handled. This way the tracer can be stopped more reliably.

Also: stop tracing after `limit` instead of `limit - 1`.