### PR TITLE
Enable tracing of newly spawned process children

### DIFF
--- a/src/tr.erl
+++ b/src/tr.erl
@@ -110,19 +110,19 @@
                    trace := none | trace_spec(),
                    tracer_pid := none | pid()}.
 
--type children_spec() :: all | first | none.
+-type new_children_flags() :: all | first | none.
 %% Describes which newly spawned children of specified processes to trace - none by default.
 %% Handy for tracing a subtree of a process hierarchy, e.g. by tracing a supervisor,
 %% its children, and newly started children.
 
 -type trace_spec() :: #{modules := module_spec(),
                         pids := pids(),
-                        children := children_spec(),
+                        new_children := new_children_flags(),
                         msg := message_event_types(),
                         msg_trigger := msg_trigger()}.
 -type trace_options() :: #{modules => module_spec(),
                            pids => pids(),
-                           children => children_spec(),
+                           new_children => new_children_flags(),
                            msg => message_event_types(),
                            msg_trigger => msg_trigger()}.
 %% Options for tracing.
@@ -300,7 +300,7 @@ trace_apps(Apps) ->
 trace(Modules) when is_list(Modules) ->
     trace(#{modules => Modules});
 trace(Opts) ->
-    DefaultOpts = #{modules => [], pids => all, children => none,
+    DefaultOpts = #{modules => [], pids => all, new_children => none,
                     msg => none, msg_trigger => after_traced_call},
     Timeout = timer:minutes(1),
     gen_server:call(?MODULE, {start_trace, call, maps:merge(DefaultOpts, Opts)}, Timeout).
@@ -858,9 +858,9 @@ msg_trace_flags(#{msg := none}) -> [].
 
 basic_trace_flags() -> [call, timestamp].
 
-process_trace_flags(#{children := all}) -> [set_on_spawn];
-process_trace_flags(#{children := first}) -> [set_on_first_spawn];
-process_trace_flags(#{children := none}) -> [].
+process_trace_flags(#{new_children := all}) -> [set_on_spawn];
+process_trace_flags(#{new_children := first}) -> [set_on_first_spawn];
+process_trace_flags(#{new_children := none}) -> [].
 
 -spec set_tracing(pids(), boolean(), erlang_trace_flags()) -> ok.
 set_tracing(all, How, FlagList) ->

--- a/src/tr.erl
+++ b/src/tr.erl
@@ -122,7 +122,7 @@
                         msg_trigger := msg_trigger()}.
 -type trace_options() :: #{modules => module_spec(),
                            pids => pids(),
-                           children := children_spec(),
+                           children => children_spec(),
                            msg => message_event_types(),
                            msg_trigger => msg_trigger()}.
 %% Options for tracing.

--- a/test/tr_SUITE.erl
+++ b/test/tr_SUITE.erl
@@ -40,7 +40,9 @@ groups() ->
                    duplicates]},
      {trace, [single_pid,
               single_pid_with_msg,
-              msg_after_traced_call]},
+              msg_after_traced_call,
+              new_children_first,
+              new_children_all]},
      {range, [ranges,
               ranges_max_depth,
               range,
@@ -199,6 +201,68 @@ msg_after_traced_call(_Config) ->
      #tr{index = 2, event = return, mfa = MFA, pid = Pid, data = 1},
      #tr{index = 3, event = send, pid = Pid, data = {ok, 1}, info = {Self, true}},
      #tr{index = 4, event = recv, pid = Pid, data = stop}] = tr:select().
+
+new_children_first(_Config) ->
+    %% Start a parent process before tracing
+    Parent = self(),
+    ParentPid = spawn_link(fun() -> spawner_loop(Parent) end),
+    receive {spawner_ready, ParentPid} -> ok end,
+
+    %% Trace only the parent with new_children => first
+    MFA = {?MODULE, traced_child_fun, 1},
+    tr:trace(#{modules => [MFA], pids => [ParentPid], new_children => first}),
+
+    %% Spawn two children from the parent - only the first should be traced
+    ParentPid ! {spawn_child, 1},
+    Child1 = receive {child_spawned, Ch1, 1} -> Ch1 end,
+    ParentPid ! {spawn_child, 2},
+    Child2 = receive {child_spawned, Ch2, 2} -> Ch2 end,
+
+    %% Wait for traces - only 2 traces from the first child (call + return)
+    wait_for_traces(2),
+    tr:stop_tracing(),
+
+    %% Clean up
+    ParentPid ! stop,
+
+    %% Verify only the first child's traces are collected
+    [#tr{index = 1, event = call, mfa = MFA, pid = Child1, data = [1]},
+     #tr{index = 2, event = return, mfa = MFA, pid = Child1, data = 1}] = tr:select(),
+
+    %% Verify Child2 is different from Child1
+    ?assertNotEqual(Child1, Child2).
+
+new_children_all(_Config) ->
+    %% Start a parent process before tracing
+    Parent = self(),
+    ParentPid = spawn_link(fun() -> spawner_loop(Parent) end),
+    receive {spawner_ready, ParentPid} -> ok end,
+
+    %% Trace only the parent with new_children => all
+    MFA = {?MODULE, traced_child_fun, 1},
+    tr:trace(#{modules => [MFA], pids => [ParentPid], new_children => all}),
+
+    %% Spawn two children from the parent - both should be traced
+    ParentPid ! {spawn_child, 1},
+    Child1 = receive {child_spawned, Ch1, 1} -> Ch1 end,
+    ParentPid ! {spawn_child, 2},
+    Child2 = receive {child_spawned, Ch2, 2} -> Ch2 end,
+
+    %% Wait for traces - 4 traces total (2 from each child)
+    wait_for_traces(4),
+    tr:stop_tracing(),
+
+    %% Clean up
+    ParentPid ! stop,
+
+    %% Verify both children's traces are collected
+    [#tr{index = 1, event = call, mfa = MFA, pid = Child1, data = [1]},
+     #tr{index = 2, event = return, mfa = MFA, pid = Child1, data = 1},
+     #tr{index = 3, event = call, mfa = MFA, pid = Child2, data = [2]},
+     #tr{index = 4, event = return, mfa = MFA, pid = Child2, data = 2}] = tr:select(),
+
+    %% Verify Child2 is different from Child1
+    ?assertNotEqual(Child1, Child2).
 
 ranges(_Config) ->
     Traces = trace_fib3(),
@@ -835,3 +899,24 @@ log(#{msg := {Format, Args}, level := Level}, #{config := Pid}) ->
     Pid ! {Level, lists:flatten(io_lib:format(Format, Args))};
 log(_Event, _Config) ->
     ok.
+
+%% Helper for new_children tests
+spawner_loop(Parent) ->
+    Parent ! {spawner_ready, self()},
+    spawner_loop_ready(Parent).
+
+spawner_loop_ready(Parent) ->
+    receive
+        {spawn_child, Id} ->
+            Child = spawn_link(fun() ->
+                                   ?MODULE:traced_child_fun(Id),
+                                   receive after infinity -> ok end
+                               end),
+            Parent ! {child_spawned, Child, Id},
+            spawner_loop_ready(Parent);
+        stop ->
+            ok
+    end.
+
+traced_child_fun(N) ->
+    N.


### PR DESCRIPTION
This uses the `erlang:trace/3` flags `set_on_spawn` and `set_on_first_spawn` to trace processes which are started after we start tracing. For example, we could start tracing a supervisor with `set_on_spawn` to trace all its children which will only be started to handle some future event we want to trigger.

I tried naming the option intuitively, but maybe `new_children` or `on_spawn` would be better than just `children`?

If you think this is useful I'll add tests (and fix existing ones) to make sure it works as expected.