### PR TITLE
Add tr:to_map/1 to convert trace records to maps

### DIFF
--- a/src/tr.erl
+++ b/src/tr.erl
@@ -40,7 +40,8 @@
          app_modules/1,
          mfarity/1,
          mfargs/2,
-         ts/1]).
+         ts/1,
+         to_map/1]).
 
 %% gen_server callbacks
 -export([init/1,
@@ -688,6 +689,15 @@ mfargs({M, F, Arity}, Args) when length(Args) =:= Arity -> {M, F, Args}.
 %% @doc Returns human-readable timestamp according to RFC 3339.
 -spec ts(tr()) -> string().
 ts(#tr{ts = TS}) -> calendar:system_time_to_rfc3339(TS, [{unit, microsecond}]).
+
+%% @doc Convert trace records to maps.
+-spec to_map(tr()) -> map().
+to_map(#tr{} = Tr) ->
+    IndexedFields = enumerate([record | record_info(fields, tr)]),
+    maps:from_list(lists:map(fun ({Index, Field}) -> {Field, element(Index, Tr)} end, IndexedFields)).
+
+enumerate(List) ->
+    lists:zip(lists:seq(1, length(List)), List).
 
 %% gen_server callbacks
 

--- a/test/tr_SUITE.erl
+++ b/test/tr_SUITE.erl
@@ -64,7 +64,8 @@ groups() ->
              match,
              do,
              next,
-             prev]},
+             prev,
+             to_map]},
      {call_stat, [simple_total,
                   tree_total,
                   simple_total_with_messages,
@@ -359,6 +360,25 @@ prev(_Config) ->
     ?assertEqual(T1, tr:prev(T4, #{pred => Pred})),
     ?assertEqual(T1, tr:prev(4, #{pred => Pred})),
     ?assertError(not_found, tr:prev(T1)).
+
+to_map(_Config) ->
+    Pid = erlang:list_to_pid("<0.115.0>"),
+    Trace = #tr{index = 5,
+                pid = Pid,
+                event = call,
+                mfa = {lists,keyfind,3},
+                data = [syntax_colors,1,[]],
+                ts = 1766078114348924,
+                info = no_info},
+    ?assertEqual(#{record => tr,
+                   index => 5,
+                   pid => Pid,
+                   event => call,
+                   mfa => {lists,keyfind,3},
+                   data => [syntax_colors,1,[]],
+                   ts => 1766078114348924,
+                   info => no_info},
+                 tr:to_map(Trace)).
 
 single_tb(_Config) ->
     tr:trace([{?MODULE, fib, 1}]),


### PR DESCRIPTION
This is the Erlang version of https://github.com/chrzaszcz/ex_doctor/pull/2, since the functionality really isn't Elixir specific and might as well sit here. Since I didn't really see a need to convert `node` / `tree` records yet, I skipped that, but the impl is universal, so it should be trivial to add if need be.